### PR TITLE
Create a GitHub PR for incoming comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ docker run --rm \
 
 Configuration is done using environment variables:
 
+* `GITHUB_USER`: GitHub user who owns the target repository
+* `GITHUB_TOKEN`: Access token for the repository
+* `GITHUB_REPOSITORY`: The name of the target repository
+* `GITHUB_AUTHOR`: Commit author name (default: `comment2gh Bot`)
+* `GITHUB_EMAIL`: Commit author e-mail
+* `GITHUB_DEFAULT_BRANCH`: Where to start the PR branches (default: `main`)
 * `SERVICE_PORT`: Port for the HTTP Service (default: 8080)
 * `CORS_ORIGIN`: Allowed origins for the request (default: `*`)
 * `FORM_SLUG`: Field name for the blog entry's slug  (default: `cmt_slug`)
@@ -49,6 +55,9 @@ Configuration is done using environment variables:
 * `FORM_EMAIL`: Field name for the commenter's e-mail address (default: `cmt_email`)
 * `FORM_URL`: Field name for the commenter's chosen URL (default: `cmt_url`)
 * `FORM_MESSAGE`: Field name for the comment message (default: `cmt_message`)
+
+Please refer to the  [GitHub documentation on Creating a Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+on how to the `GITHUB_TOKEN`.
 
 ## API
 

--- a/src/github.py
+++ b/src/github.py
@@ -1,0 +1,215 @@
+""" Module for GitHub API access
+
+There are available libraries for accessing the GitHub API.
+However, there is not a lot of documentation. It turned out to be easier to call the API directly.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+import base64
+import json
+import os
+
+import logging
+
+from tornado.httpclient import AsyncHTTPClient, HTTPRequest
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _assert_value(value, name):
+    if not value:
+        raise ValueError(f"Attribute %s is required, but was None!" % name)
+
+
+@dataclass(frozen=True)
+class GithubConfiguration(object):
+    DEFAULT_BRANCH = "main"
+    DEFAULT_AUTHOR = "comment2gh Bot"
+
+    user: str
+    token: str
+    repository: str
+    email: str
+    author: str = DEFAULT_AUTHOR
+    branch: str = DEFAULT_BRANCH
+
+    @staticmethod
+    def from_environment():
+        return GithubConfiguration(
+            user=os.getenv("GITHUB_USER", None),
+            token=os.getenv("GITHUB_TOKEN", None),
+            repository=os.getenv("GITHUB_REPOSITORY", None),
+            email=os.getenv("GITHUB_EMAIL", None),
+            author=os.getenv("GITHUB_AUTHOR", GithubConfiguration.DEFAULT_AUTHOR),
+            branch=os.getenv("GITHUB_DEFAULT_BRANCH", GithubConfiguration.DEFAULT_BRANCH),
+
+        )
+
+    def __post_init__(self):
+        for attr in [
+            'user',
+            'token',
+            'repository',
+            'email',
+            'author',
+            'branch'
+        ]:
+            _assert_value(self.__getattribute__(attr), attr)
+
+    def create_auth_header(self):
+        auth = f"%s:%s" % (self.user, self.token)
+        b64 = base64.b64encode(auth.encode("utf-8"))
+        return {
+            "Authorization": f"Basic %s" % b64.decode("utf-8")
+        }
+
+
+class GithubReferenceAccess(object):
+    def __init__(self, cfg: GithubConfiguration):
+        if cfg is None:
+            raise ValueError("Configuration must be provided!")
+        self._cfg = cfg
+
+    async def retrieve_default_head(self) -> Optional[str]:
+        http_client = AsyncHTTPClient()
+
+        req = HTTPRequest(
+            url=f"https://api.github.com/repos/%s/%s/git/matching-refs/%s" % (
+                self._cfg.user,
+                self._cfg.repository,
+                f"heads/%s" % self._cfg.branch
+            ),
+            headers=self._cfg.create_auth_header() | {
+                "Accept": "application/vnd.github.v3+json"
+            }
+        )
+
+        response = await http_client.fetch(req, raise_error=False)
+
+        sha = None
+
+        if response.code == 200:
+            result = json.loads(response.body.decode("utf-8"))
+            if len(result):
+                sha = result[0]["object"]["sha"]
+        else:
+            LOGGER.error("Error %i when fetching ref id: %s", response.code, response.body)
+
+        return sha
+
+    async def create_branch(self, sha: str, branch: str) -> bool:
+        http_client = AsyncHTTPClient()
+
+        req = HTTPRequest(
+            method="POST",
+            url=f"https://api.github.com/repos/%s/%s/git/refs" % (
+                self._cfg.user,
+                self._cfg.repository
+            ),
+            headers=self._cfg.create_auth_header() | {
+                "Accept": "application/vnd.github.v3+json"
+            },
+            body=json.dumps({
+                "ref": f"refs/heads/%s" % branch,
+                "sha": sha
+            })
+        )
+
+        response = await http_client.fetch(req, raise_error=False)
+
+        if response.code != 201:
+            LOGGER.error("Error %i when creating ref id: %s", response.code, response.body)
+
+        return response.code == 201
+
+
+class GithubUpload(object):
+    def __init__(self, cfg: GithubConfiguration):
+        if cfg is None:
+            raise ValueError("Configuration must be provided!")
+        self._cfg = cfg
+
+    async def upload(self,
+                     branch: str,
+                     path: str,
+                     message: str,
+                     committer_name: str, committer_email: str,
+                     content: str):
+        b64 = base64.b64encode(content.encode("utf-8"))
+
+        http_client = AsyncHTTPClient()
+
+        req = HTTPRequest(
+            method="PUT",
+            url=f"https://api.github.com/repos/%s/%s/contents/%s" % (
+                self._cfg.user,
+                self._cfg.repository,
+                path
+            ),
+            headers=self._cfg.create_auth_header() | {
+                "Accept": "application/vnd.github.v3+json"
+            },
+            body=json.dumps({
+                "branch": branch,
+                "message": message,
+                "committer": {
+                    "name": committer_name,
+                    "email": committer_email
+                },
+                "content": b64.decode("utf-8")
+            })
+        )
+
+        response = await http_client.fetch(req, raise_error=False)
+
+        if response.code != 201:
+            LOGGER.error("Error %i when uploading content: %s", response.code, response.body)
+
+        return response.code == 201
+
+
+class GithubPR(object):
+    def __init__(self, cfg: GithubConfiguration):
+        if cfg is None:
+            raise ValueError("Configuration must be provided!")
+        self._cfg = cfg
+
+    async def create_pr(self,
+                        title: str,
+                        head: str, base: str,
+                        body: str,
+                        maintainer_can_modify: Optional[bool] = True) -> Optional[int]:
+        http_client = AsyncHTTPClient()
+
+        req = HTTPRequest(
+            method="POST",
+            url=f"https://api.github.com/repos/%s/%s/pulls" % (
+                self._cfg.user,
+                self._cfg.repository
+            ),
+            headers=self._cfg.create_auth_header() | {
+                "Accept": "application/vnd.github.v3+json"
+            },
+            body=json.dumps({
+                "title": title,
+                "head": head,
+                "base": base,
+                "body": body,
+                "maintainer_can_modify": maintainer_can_modify
+            })
+        )
+
+        response = await http_client.fetch(req, raise_error=False)
+
+        if response.code != 201:
+            LOGGER.error("Error %i when creating PR: %s", response.code, response.body)
+
+        issue = None
+
+        if response.code == 201:
+            result = json.loads(response.body.decode("utf-8"))
+            issue = result.get("number", None)
+
+        return issue

--- a/src/processor.py
+++ b/src/processor.py
@@ -1,0 +1,114 @@
+""" Module for comment processing """
+
+import form
+from github import GithubConfiguration, GithubReferenceAccess, GithubUpload, GithubPR
+
+from typing import Optional
+
+import logging
+
+LOGGER = logging.getLogger(__name__)
+
+
+class CommentFormatter(object):
+    def __init__(self, cmt: form.Comment):
+        if cmt is None:
+            raise ValueError("Comment must not be None!")
+        self._cmt = cmt
+
+    def branch_name(self) -> str:
+        return "comment-%s" % self._cmt.cid
+
+    def file_content(self) -> str:
+        return f"""\
+id: %s
+name: %s
+email: %s
+url: %s
+date: %s
+message: |
+    %s
+
+""" \
+               % (self._cmt.cid,
+                  self._cmt.name,
+                  self._cmt.email,
+                  self._cmt.url,
+                  self._cmt.date,
+                  self._cmt.message.rstrip('\n').replace('\n', '\n    '))
+
+    def commit_path(self) -> str:
+        return "_data/comments/%s/%s.yml" % (self._cmt.slug, self._cmt.cid)
+
+    def commit_message(self) -> str:
+        return "Comment %s" % self._cmt.cid
+
+    def pr_title(self) -> str:
+        return "Blog Comment %s" % self._cmt.cid
+
+    def pr_body(self) -> str:
+        return f"""\
+Please consider this blog comment.
+
+## Meta Data
+
+Slug: %s
+Date: %s
+Name: %s
+E-Mail: %s
+URL: %s
+
+## Message
+
+%s""" % (
+            self._cmt.slug,
+            self._cmt.date,
+            self._cmt.name,
+            self._cmt.email,
+            self._cmt.url,
+            self._cmt.message
+        )
+
+
+class CommentProcessor(object):
+    def __init__(self, cfg: GithubConfiguration):
+        if cfg is None:
+            raise ValueError("Configuration must be provided!")
+        self._cfg = cfg
+
+    async def comment_to_github_pr(self, cmt: form.Comment) -> Optional[int]:
+        formatter = CommentFormatter(cmt)
+
+        if not await self._create_branch(formatter):
+            return None
+
+        if not await self._upload_file(formatter):
+            return None
+
+        return await self._create_pr(formatter)
+
+    async def _create_branch(self, formatter) -> bool:
+        ref = GithubReferenceAccess(self._cfg)
+
+        main_head = await ref.retrieve_default_head()
+        return await ref.create_branch(
+            branch=formatter.branch_name(),
+            sha=main_head
+        )
+
+    async def _upload_file(self, formatter) -> bool:
+        return await GithubUpload(self._cfg).upload(
+            branch=formatter.branch_name(),
+            path=formatter.commit_path(),
+            message=formatter.commit_message(),
+            committer_name=self._cfg.author,
+            committer_email=self._cfg.email,
+            content=formatter.file_content())
+
+    async def _create_pr(self, formatter) -> Optional[int]:
+        return await GithubPR(self._cfg).create_pr(
+            head=formatter.branch_name(),
+            base=self._cfg.branch,
+            title=formatter.pr_title(),
+            body=formatter.pr_body()
+        )

--- a/test/test_github.py
+++ b/test/test_github.py
@@ -1,0 +1,111 @@
+""" Test the processor module """
+from unittest import mock
+import pytest
+
+import os
+
+# noinspection PyUnresolvedReferences
+# noinspection PyPackageRequirements
+import github
+
+
+class TestGithubConfiguration:
+    @mock.patch.dict(os.environ, {
+        "GITHUB_USER": "1",
+        "GITHUB_TOKEN": "2",
+        "GITHUB_REPOSITORY": "3",
+        "GITHUB_EMAIL": "4"
+    }, clear=True)
+    def test_minimal_config(self):
+        cfg = github.GithubConfiguration.from_environment()
+
+        assert cfg.user == "1"
+        assert cfg.token == "2"
+        assert cfg.repository == "3"
+        assert cfg.email == "4"
+
+        # default values
+        assert cfg.author == "comment2gh Bot"
+        assert cfg.branch == "main"
+
+    @mock.patch.dict(os.environ, {
+        "GITHUB_USER": "1",
+        "GITHUB_TOKEN": "2",
+        "GITHUB_REPOSITORY": "3",
+        "GITHUB_AUTHOR": "4",
+        "GITHUB_EMAIL": "5",
+        "GITHUB_DEFAULT_BRANCH": "6"
+    }, clear=True)
+    def test_full_config(self):
+        cfg = github.GithubConfiguration.from_environment()
+
+        assert cfg.user == "1"
+        assert cfg.token == "2"
+        assert cfg.repository == "3"
+        assert cfg.author == "4"
+        assert cfg.email == "5"
+        assert cfg.branch == "6"
+
+    def test_missing_values(self):
+        values = {
+            "user": "1",
+            "token": "2",
+            "repository": "3",
+            "email": "4"
+        }
+        for key in values.keys():
+            args = dict(values)
+            args[key] = None
+            with pytest.raises(ValueError):
+                github.GithubConfiguration(**args)
+
+    def test_empty_required(self):
+        values = {
+            "user": "1",
+            "token": "2",
+            "repository": "3",
+            "email": "4"
+        }
+        with pytest.raises(ValueError):
+            github.GithubConfiguration(author=None, **values)
+        with pytest.raises(ValueError):
+            github.GithubConfiguration(branch=None, **values)
+
+    @mock.patch.dict(os.environ, {
+        "GITHUB_USER": "1",
+        "GITHUB_TOKEN": "2",
+        "GITHUB_REPOSITORY": "3",
+        "GITHUB_EMAIL": "4"
+    }, clear=True)
+    def test_auth_headers(self):
+        cfg = github.GithubConfiguration.from_environment()
+
+        hdr = cfg.create_auth_header()
+
+        assert len(hdr.keys()) == 1
+        assert "Authorization" in hdr
+        assert hdr["Authorization"] == "Basic MToy"  # Don't be a basic M toy with your credentials!
+
+
+class TestGithubReferenceAccess:
+    def test_null_cfg(self):
+        with pytest.raises(ValueError):
+            github.GithubReferenceAccess(None)
+
+# TODO mock tests here
+
+
+class TestGithubUpload:
+    def test_null_cfg(self):
+        with pytest.raises(ValueError):
+            github.GithubUpload(None)
+
+# TODO mock tests here
+
+
+class TestGithubPR:
+    def test_null_cfg(self):
+        with pytest.raises(ValueError):
+            github.GithubPR(None)
+
+# TODO mock tests here

--- a/test/test_processor.py
+++ b/test/test_processor.py
@@ -1,0 +1,119 @@
+""" Test the processor module """
+
+import pytest
+
+# noinspection PyUnresolvedReferences
+# noinspection PyPackageRequirements
+import form
+# noinspection PyUnresolvedReferences
+# noinspection PyPackageRequirements
+import processor
+
+
+class TestCommentFormatter:
+    def test_null_comment(self):
+        with pytest.raises(ValueError):
+            processor.CommentFormatter(None)
+
+    def test_full_comment(self):
+        values = {
+            "slug": "1",
+            "name": "2",
+            "email": "3",
+            "url": "4",
+            "message": "5"
+        }
+        cmt = form.Comment(**values)
+        formatter = processor.CommentFormatter(cmt)
+
+        assert formatter.branch_name() == "comment-" + str(cmt.cid)
+        assert formatter.file_content() == """\
+id: """ + str(cmt.cid) + """
+name: 2
+email: 3
+url: 4
+date: """ + cmt.date + """
+message: |
+    5
+
+"""
+        assert formatter.commit_path() == "_data/comments/" + cmt.slug + "/" + str(cmt.cid) + ".yml"
+        assert formatter.commit_message() == "Comment " + str(cmt.cid)
+        assert formatter.pr_title() == "Blog Comment " + str(cmt.cid)
+        assert formatter.pr_body() == """\
+Please consider this blog comment.
+
+## Meta Data
+
+Slug: 1
+Date: """ + cmt.date + """
+Name: 2
+E-Mail: 3
+URL: 4
+
+## Message
+
+5"""
+
+    def test_multiline_comment(self):
+        values = {
+            "slug": "1",
+            "name": "2",
+            "email": "3",
+            "url": "4",
+            "message": """\
+This
+is
+a
+
+multiline
+message.
+"""
+        }
+        cmt = form.Comment(**values)
+        formatter = processor.CommentFormatter(cmt)
+
+        assert formatter.file_content() == """\
+id: """ + str(cmt.cid) + """
+name: 2
+email: 3
+url: 4
+date: """ + cmt.date + """
+message: |
+    This
+    is
+    a
+    
+    multiline
+    message.
+
+"""
+
+        assert formatter.pr_body() == """\
+Please consider this blog comment.
+
+## Meta Data
+
+Slug: 1
+Date: """ + cmt.date + """
+Name: 2
+E-Mail: 3
+URL: 4
+
+## Message
+
+This
+is
+a
+
+multiline
+message.
+"""
+
+
+class TestCommentProcessor:
+    def test_null_cfg(self):
+        with pytest.raises(ValueError):
+            processor.CommentProcessor(None)
+
+# TODO mock tests here


### PR DESCRIPTION
Uses the following API endpoints for create a GitHub PR with the provided comment:
* https://docs.github.com/en/rest/pulls/pulls#create-a-pull-request
* https://docs.github.com/en/rest/repos/contents#create-a-file
* https://docs.github.com/en/rest/git/refs

There are available libraries for accessing the GitHub API.
However, there is not a lot of documentation. It turned out to be easier to call the API directly.
