### PR TITLE
Remove e-mail from logging  in the form handling.

### DIFF
--- a/src/form.py
+++ b/src/form.py
@@ -11,7 +11,6 @@ import os
 
 import logging
 
-LOG_FORMAT = '%(levelname) -10s %(asctime)s %(name) -15s %(lineno) -5d: %(message)s'
 LOGGER = logging.getLogger(__name__)
 
 

--- a/src/form.py
+++ b/src/form.py
@@ -69,7 +69,7 @@ class Comment:
     date: str = field(init=False, default="")
     slug: str
     name: str
-    email: str
+    email: str = field(repr=False)
     message: str
     url: Optional[str] = None
 


### PR DESCRIPTION
This PR removes the e-mail address from the comment representation so that it does not appear in logs anymore.