### PR TITLE
Cancel old docker runs when a newer action has been triggered

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,6 +15,10 @@ env:
   IMAGE_NAME: mrtux/comment2gh
   TARGET_PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Docker runs use a lot of resources. Use the `concurrency` feature to cancel stale runs when a newer commit is available on the main branch.